### PR TITLE
Added 'locations_with [symbols]' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 *.pyc
+.env

--- a/modules/puzzles/module.py
+++ b/modules/puzzles/module.py
@@ -25,3 +25,12 @@ class Puzzles(TelegramModule):
         results = util.location_by_length(length)
         self.respond('Er zijn %i resultaten met lengte %s' % (len(results), length))
         self.respond(', '.join([x.name for x in results]))
+
+    @command
+    def locations_with(self, symbols):
+        """
+        Geeft een lijst met alle locaties waarvan de naam alle gegeven symbolen bevat
+        """
+        results = util.locations_containing_symbols(symbols)
+        self.respond('Er zijn %i resultaten die de symbolen \'%s\' bevatten' % (len(results), symbols))
+        self.respond(', '.join([x.name for x in results]))

--- a/modules/puzzles/util.py
+++ b/modules/puzzles/util.py
@@ -43,3 +43,19 @@ def building_by_number(number):
 @lru_cache()
 def location_by_length(length):
     return [l for l in locations() if len(l.name) == int(length)]
+
+
+@lru_cache()
+def locations_containing_symbols(symbols):
+    # Transform symbol list to dict, counting the occurences of all symbols
+    s_dict = dict();
+    for s in symbols.lower():
+        if s in s_dict:
+            s_dict[s] += 1
+        else:
+            s_dict[s] = 1
+
+    ls = locations()
+    for symbol in s_dict:
+        ls = [l for l in ls if l.name.lower().count(symbol) >= s_dict[symbol]]
+    return ls

--- a/modules/puzzles/util.py
+++ b/modules/puzzles/util.py
@@ -54,4 +54,18 @@ def locations_containing_symbols(symbols):
     ls = locations()
     for symbol in s_dict:
         ls = [l for l in ls if l.name.lower().count(symbol) >= s_dict[symbol]]
-    return ls
+
+    return remove_duplicate_locations(ls)
+
+
+@lru_cache()
+def remove_duplicate_locations(locations):
+    results = []
+    storedLocations = []
+    for l in locations:
+        # Normalize name by removing spaces and putting it in lowercase
+        normalizedL = l.name.replace(' ', '').lower()
+        if normalizedL not in storedLocations:
+            results.append(l)
+            storedLocations.append(normalizedL)
+    return results

--- a/modules/puzzles/util.py
+++ b/modules/puzzles/util.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from collections import Counter
 
 from modules.puzzles.model import Building, ArtWork
 
@@ -48,12 +49,7 @@ def location_by_length(length):
 @lru_cache()
 def locations_containing_symbols(symbols):
     # Transform symbol list to dict, counting the occurences of all symbols
-    s_dict = dict();
-    for s in symbols.lower():
-        if s in s_dict:
-            s_dict[s] += 1
-        else:
-            s_dict[s] = 1
+    s_dict = Counter(symbols.lower())
 
     ls = locations()
     for symbol in s_dict:


### PR DESCRIPTION
'locations_with [symbols]' allows the user to retrieve a list of all locations that contain a set of symbols (usually characters). The code takes into account multiple occurences of the same symbol and treats upper and lower case symbols as equal. It does not matter in which order the symbols are given.

Ex. 'locations_with hata' should return 6 results (Het Signaal being counted twice).