### PR TITLE
Removed caching in remove_duplicate_locations method

### DIFF
--- a/modules/puzzles/util.py
+++ b/modules/puzzles/util.py
@@ -58,7 +58,6 @@ def locations_containing_symbols(symbols):
     return remove_duplicate_locations(ls)
 
 
-@lru_cache()
 def remove_duplicate_locations(locations):
     results = []
     storedLocations = []


### PR DESCRIPTION
Caching resulted in unhashable error. Since the input and therefore output of this method is probably rather unique, we ditch the caching here.